### PR TITLE
Remove crossorigin attribute from fontawesome link element

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
     <title>bitionaire.org</title>
 
     <link rel="stylesheet" href="bitionaire.css">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.9/css/all.css" integrity="sha384-5SOiIsAziJl6AWe0HWRKTXlfcSHKmYV4RBF18PPJ173Kzn7jzMyFuTtk8JA7QQG1" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.9/css/all.css" integrity="sha384-5SOiIsAziJl6AWe0HWRKTXlfcSHKmYV4RBF18PPJ173Kzn7jzMyFuTtk8JA7QQG1">
 </head>
 <body>
 


### PR DESCRIPTION
In [index.html:8](https://github.com/bitionaire/bitionaire.org/blob/7d1baf89d872a1d665f3c49315af6b72b823899b/static/index.html#L8) you use the crossorigin attribute for the fontawesome stylesheet.
As per spec [1] this will use a CORS request to load the ressource, which is only needed when images are to be loaded into a canvas [2].
So it can be removed.

[1] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin
[2] https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_Enabled_Image